### PR TITLE
feat: update newleaf to v0.3.0

### DIFF
--- a/src/flappy_bird/components/config/cCoins.h
+++ b/src/flappy_bird/components/config/cCoins.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <map>
 #include <string>
 
@@ -13,7 +14,7 @@ struct CCoins {
     uint32_t coins{};
 
     CCoins() = default;
-    explicit CCoins(uint32_t mp, uint32_t p) : max_coins(mp), coins(p) {}
+    explicit CCoins(uint32_t mp, uint32_t p) : max_coins(mp), coins(std::min(p, mp)) {}
 
     void print() const { APP_BACKTRACE("\t\tmax_coins: {0}\n\t\t\t\t\t\tcoins: {1}", max_coins, coins); }
 

--- a/src/flappy_bird/components/config/cPipes.h
+++ b/src/flappy_bird/components/config/cPipes.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <map>
 #include <string>
 
@@ -13,7 +14,7 @@ struct CPipes {
     uint32_t pipes{0};
 
     CPipes() = default;
-    explicit CPipes(uint32_t mp, uint32_t p) : max_pipes(mp), pipes(p) {}
+    explicit CPipes(uint32_t mp, uint32_t p) : max_pipes(mp), pipes(std::min(p, mp)) {}
 
     void print() const { APP_BACKTRACE("\t\tmax_pipes: {0}\n\t\t\t\t\t\tpipes: {1}", max_pipes, pipes); }
 

--- a/src/flappy_bird/components/meta/cTimer.h
+++ b/src/flappy_bird/components/meta/cTimer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <map>
 #include <string>
 
@@ -13,7 +14,7 @@ struct CTimer {
     uint32_t left{20};
 
     CTimer() = default;
-    explicit CTimer(uint32_t t, uint32_t l) : max_time(t), left(l) {}
+    explicit CTimer(uint32_t t, uint32_t l) : max_time(t), left(std::min(l, t)) {}
 
     void print() const { APP_BACKTRACE("\t\tmax_time: {0}\n\t\t\t\t\t\tleft: {1}", max_time, left); }
 

--- a/src/flappy_bird/components/register.cpp
+++ b/src/flappy_bird/components/register.cpp
@@ -20,7 +20,7 @@ void register_components() {
     .data<&CCoins::coins>("coins"_hs)
     .func<&CCoins::print>("print"_hs)
     .func<&CCoins::to_map>("to_map"_hs)
-    .func<&nl::assign<CCoins>, entt::as_ref_t>("assign"_hs);
+    .func<&nl::assign<CCoins>>("assign"_hs);
 
   entt::meta<CPipes>()
     .type("pipes"_hs)
@@ -29,7 +29,7 @@ void register_components() {
     .data<&CPipes::pipes>("pipes"_hs)
     .func<&CPipes::print>("print"_hs)
     .func<&CPipes::to_map>("to_map"_hs)
-    .func<&nl::assign<CPipes>, entt::as_ref_t>("assign"_hs);
+    .func<&nl::assign<CPipes>>("assign"_hs);
 
   entt::meta<CScore>()
     .type("score"_hs)
@@ -37,7 +37,7 @@ void register_components() {
     .data<&CScore::score>("score"_hs)
     .func<&CScore::print>("print"_hs)
     .func<&CScore::to_map>("to_map"_hs)
-    .func<&nl::assign<CScore>, entt::as_ref_t>("assign"_hs);
+    .func<&nl::assign<CScore>>("assign"_hs);
 
   entt::meta<CTimer>()
     .type("timer"_hs)
@@ -46,6 +46,6 @@ void register_components() {
     .data<&CTimer::left>("left"_hs)
     .func<&CTimer::print>("print"_hs)
     .func<&CTimer::to_map>("to_map"_hs)
-    .func<&nl::assign<CTimer>, entt::as_ref_t>("assign"_hs);
+    .func<&nl::assign<CTimer>>("assign"_hs);
 }
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -2,7 +2,7 @@ include(FetchContent)
 FetchContent_Declare(
     newleaf
     GIT_REPOSITORY https://github.com/kafkaphoenix/newleaf.git
-    GIT_TAG        v0.2.0
+    GIT_TAG        v0.3.0
 )
 
 FetchContent_MakeAvailable(newleaf)


### PR DESCRIPTION
Remove entt::as_ref_t from component assign functions (not needed anymore)